### PR TITLE
Updated Zabbix roles

### DIFF
--- a/roles/zabbix-agent/tasks/main.yml
+++ b/roles/zabbix-agent/tasks/main.yml
@@ -24,13 +24,22 @@
         owner: root
         group: root
 
-    - name: Zabbix COnfig
+    - name: Zabbix Config
       template:
         src: zabbix_agent.j2
-        dest: /usr/local/etc/zabbix_agentd.conf
+        dest: /etc/zabbix/zabbix_agentd.conf
         owner: root
         group: root
         mode: "644"
+
+    - name: Change Zabbix Agent Command Path
+      copy:
+        src: /usr/local/sbin/zabbix_agentd
+        dest: /usr/sbin/zabbix_agentd
+        remote_src: yes
+        owner: root
+        group: root
+        mode: "755"
 
     - name: Zabbix Galera Database Template
       template:

--- a/roles/zabbix-agent/templates/agent-systemd.j2
+++ b/roles/zabbix-agent/templates/agent-systemd.j2
@@ -1,12 +1,14 @@
 [Unit]
 Description=Zabbix Agent Service
 After=syslog.target
+After=network.target
 Documentation=https://www.zabbix.com/documentation/current/manual/concepts/agent
 
 [Service]
 Type=oneshot
-Environment="CONFFILE=/usr/local/etc/zabbix_agentd.conf"
-ExecStart=/usr/local/sbin/zabbix_agentd -c $CONFFILE
+Environment="CONFFILE=/etc/zabbix/zabbix_agentd.conf"
+ExecStart=/usr/sbin/zabbix_agentd -c $CONFFILE
+PIDFile=/run/zabbix_agentd.pid
 RemainAfterExit=yes
 User=zabbix
 Group=zabbix

--- a/roles/zabbix-agent/templates/agent-systemd.j2
+++ b/roles/zabbix-agent/templates/agent-systemd.j2
@@ -4,14 +4,10 @@ After=syslog.target
 Documentation=https://www.zabbix.com/documentation/current/manual/concepts/agent
 
 [Service]
-Type=forking
-Restart=on-failure
-KillMode=control-group
-PIDFile=/tmp/zabbix_agentd.pid
+Type=oneshot
 Environment="CONFFILE=/usr/local/etc/zabbix_agentd.conf"
 ExecStart=/usr/local/sbin/zabbix_agentd -c $CONFFILE
-ExecStop=/bin/kill -SIGTERM $MAINPID
-RestartSec=10s
+RemainAfterExit=yes
 User=zabbix
 Group=zabbix
 

--- a/roles/zabbix-agent/templates/zabbix_agent.j2
+++ b/roles/zabbix-agent/templates/zabbix_agent.j2
@@ -8,7 +8,7 @@
 #
 # Mandatory: no
 # Default:
-# PidFile=/tmp/zabbix_agentd.pid
+PidFile=/run/zabbix_agentd.pid
 
 ### Option: LogType
 #	Specifies where log messages are written to:

--- a/roles/zabbix-server/tasks/main.yml
+++ b/roles/zabbix-server/tasks/main.yml
@@ -64,13 +64,22 @@
         owner: root
         group: root
 
-    - name: Zabbix COnfig
+    - name: Zabbix Config
       template:
         src: zabbix-conf.j2
-        dest: /usr/local/etc/zabbix_server.conf
+        dest: /etc/zabbix/zabbix_server.conf
         owner: root
         group: root
         mode: "644"
+
+    - name: Change Zabbix Server Command Path
+      copy:
+        src: /usr/local/sbin/zabbix_server
+        dest: /usr/sbin/zabbix_server
+        remote_src: yes
+        owner: root
+        group: root
+        mode: "755"
 
     - name: make Zabbix Frontend
       copy:

--- a/roles/zabbix-server/templates/server-systemd.j2
+++ b/roles/zabbix-server/templates/server-systemd.j2
@@ -1,12 +1,14 @@
 [Unit]
 Description=Zabbix Server Service
 After=syslog.target
+After=network.target
 Documentation=https://www.zabbix.com/documentation/current/
 
 [Service]
 Type=oneshot
-Environment="CONFFILE=/usr/local/etc/zabbix_server.conf"
-ExecStart=/usr/local/sbin/zabbix_server  -c $CONFFILE
+Environment="CONFFILE=/etc/zabbix/zabbix_server.conf"
+ExecStart=/usr/sbin/zabbix_server  -c $CONFFILE
+PIDFile=/run/zabbix_server.pid
 RemainAfterExit=yes
 User=zabbix
 Group=zabbix

--- a/roles/zabbix-server/templates/server-systemd.j2
+++ b/roles/zabbix-server/templates/server-systemd.j2
@@ -4,14 +4,10 @@ After=syslog.target
 Documentation=https://www.zabbix.com/documentation/current/
 
 [Service]
-Type=forking
-Restart=on-failure
-KillMode=control-group
-PIDFile=/tmp/zabbix_server.pid
+Type=oneshot
 Environment="CONFFILE=/usr/local/etc/zabbix_server.conf"
 ExecStart=/usr/local/sbin/zabbix_server  -c $CONFFILE
-ExecStop=/bin/kill -SIGTERM $MAINPID
-RestartSec=10s
+RemainAfterExit=yes
 User=zabbix
 Group=zabbix
 

--- a/roles/zabbix-server/templates/zabbix-conf.j2
+++ b/roles/zabbix-server/templates/zabbix-conf.j2
@@ -65,7 +65,7 @@ LogFile=/var/log/zabbix/zabbix-server/zabbix_server.log
 #
 # Mandatory: no
 # Default:
-# PidFile=/tmp/zabbix_server.pid
+PidFile=/run/zabbix_server.pid
 
 ### Option: SocketDir
 #	IPC socket directory.

--- a/roles/zabbix-setup/tasks/main.yml
+++ b/roles/zabbix-setup/tasks/main.yml
@@ -54,4 +54,12 @@
         mode: "770"
         state: directory
 
+    - name: Create Zabbix Config File
+      file:
+        path: /etc/zabbix
+        owner: root
+        group: root
+        mode: "655"
+        state: directory
+
     


### PR DESCRIPTION
* Both Zabbix Agent and Server use ```/run``` as PID location
* Change Zabbix command line location
* Updated Templates